### PR TITLE
Feature/import fixes

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -1,9 +1,13 @@
-import random
+import os
+import sys
 import time
+import random
 from enum import Enum
 
-import matplotlib.pyplot as plt
+sys.path.insert(0, os.getcwd())
+
 import networkx as nx
+import matplotlib.pyplot as plt
 
 from Ahc import ComponentModel, Event, ConnectorTypes, Topology
 from Ahc import ComponentRegistry

--- a/tests/testbroadcasting.py
+++ b/tests/testbroadcasting.py
@@ -1,7 +1,11 @@
+import os
+import sys
 import random
 
-import matplotlib.pyplot as plt
+sys.path.insert(0, os.getcwd())
+
 import networkx as nx
+import matplotlib.pyplot as plt
 
 from Ahc import ComponentModel, Event, ConnectorTypes, Topology, EventTypes
 from Ahc import ComponentRegistry

--- a/tests/testchannels.py
+++ b/tests/testchannels.py
@@ -1,5 +1,10 @@
-import matplotlib.pyplot as plt
+import os
+import sys
+
+sys.path.insert(0, os.getcwd())
+
 import networkx as nx
+import matplotlib.pyplot as plt
 
 from Ahc import ComponentModel, Event, Topology, ComponentRegistry, GenericMessage, GenericMessageHeader, EventTypes
 from Channels import P2PFIFOFairLossChannel

--- a/tests/testcomposition.py
+++ b/tests/testcomposition.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.insert(0, os.getcwd())
+
 from Ahc import ComponentModel, Event, ConnectorTypes, Topology, EventTypes
 from Ahc import ComponentRegistry
 

--- a/tests/testnx.py
+++ b/tests/testnx.py
@@ -1,5 +1,10 @@
-import matplotlib.pyplot as plt
+import os
+import sys
+
+sys.path.insert(0, os.getcwd())
+
 import networkx as nx
+import matplotlib.pyplot as plt
 
 def main():
   inf = float('inf')


### PR DESCRIPTION
- Fixed import errors on test scripts under `tests/`
- Test scripts was trying to import upper directory modules without proper Python project structure, so I've used `sys.path.insert(0, os.getcwd())` to include the upper directory path to the module path variable.